### PR TITLE
Fix README and GET methods for Localisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,13 +519,13 @@ This is an unofficial Python client for the NinjaRMM (NinjaOne) API. It is not a
 
 ## Support
 
-- 📖 [Documentation](https://github.com/yourusername/ninjapy#readme)
-- 🐛 [Bug Reports](https://github.com/yourusername/ninjapy/issues)
-- 💡 [Feature Requests](https://github.com/yourusername/ninjapy/issues)
+- 📖 [Documentation](https://github.com/jstrn/ninjapy#readme)
+- 🐛 [Bug Reports](https://github.com/jstrn/ninjapy/issues)
+- 💡 [Feature Requests](https://github.com/jstrn/ninjapy/issues)
 - 📝 [Changelog](CHANGELOG.md)
 
 ## Links
 
 - [NinjaRMM Official Documentation](https://app.ninjarmm.com/apidocs)
 - [PyPI Package](https://pypi.org/project/ninjapy/)
-- [GitHub Repository](https://github.com/yourusername/ninjapy) 
+- [GitHub Repository](https://github.com/jstrn/ninjapy) 

--- a/ninjapy/client.py
+++ b/ninjapy/client.py
@@ -2247,7 +2247,7 @@ class NinjaRMMClient:
         response.raise_for_status()
         return response.json()
 
-    def get_location(self, org_id: int) -> List[Dict]:
+    def get_locations_by_organization_id(self, org_id: int) -> List[Dict]:
         """Get all locations for an organization
 
         Args:
@@ -2256,10 +2256,9 @@ class NinjaRMMClient:
         Returns:
             List[Dict]: List of location objects
         """
-        url = f"{self.base_url}/v2/organization/{org_id}/locations"
-        response = self.session.get(url)
-        response.raise_for_status()
-        return response.json()
+        return self._request(
+            "GET", f"/v2/organization/{org_id}/locations"
+        )
 
     def get_locations(self) -> List[Dict]:
         """Get all locations for an organization
@@ -2268,10 +2267,7 @@ class NinjaRMMClient:
         Returns:
             List[Dict]: List of location objects
         """
-        url = f"{self.base_url}/v2/locations"
-        response = self.session.get(url)
-        response.raise_for_status()
-        return response.json()
+        return self._request("GET", "/v2/locations")
 
     def update_location(
         self,


### PR DESCRIPTION
The README was containing placeholder text in links, I used the account name in them.

Locations methods were not using the _request method so there was no authentication. Also renamed the method to get Locations for a given organization ID to be clearer.